### PR TITLE
Replace supervisor with s6

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ will resort to the default, which is Debian and Apache server.
 ```bash
 git clone git@github.com:samhwang/docker-php-image.git
 cd docker-php
-docker build -f Dockerfile-[APACHE/nginx]-[BLANK/alpine] -t samhwang/php:latest .
+docker build -f [APACHE/nginx]-[BLANK/alpine].Dockerfile -t samhwang/php:latest .
 ```

--- a/alpine-apache.Dockerfile
+++ b/alpine-apache.Dockerfile
@@ -1,14 +1,16 @@
 FROM php:7.4.4-fpm-alpine3.11
 LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
-# Install apache and other OS support for images.
-RUN apk update && \
-    apk add --no-cache bash apache2 apache2-proxy apache2-ssl supervisor libjpeg-turbo-dev libpng-dev freetype-dev libzip-dev postgresql-dev;
+# Install Apache and other OS support for images.
+ARG S6_VERSION=1.22.1.0
+RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+    tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
+    rm /tmp/s6-overlay-amd64.tar.gz && \
+    apk update && \
+    apk add --no-cache bash apache2 apache2-proxy apache2-ssl libjpeg-turbo-dev libpng-dev freetype-dev libzip-dev postgresql-dev && \
+    rm -rf /var/cache/apk/*;
 
-# Configure Apache, PHP Modules and Supervisor
-WORKDIR /var/www/html
-COPY public ./public
-COPY rootfs ./rootfs
+# Configure Apache, PHP Modules and S6
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install pdo_mysql mysqli pdo_pgsql pgsql gd zip; \
@@ -19,17 +21,19 @@ RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.
     echo 'Include /etc/apache2/sites-enabled/*.conf' >> /etc/apache2/httpd.conf && \
     ln -s /usr/sbin/httpd /usr/sbin/apachectl && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
-    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
-    mkdir /etc/supervisor && mkdir /etc/supervisor/conf.d && \
-    cp rootfs/supervisor/supervisord.conf /etc/supervisor/supervisord.conf && \
-    cp rootfs/supervisor/conf.d/php-fpm.conf /etc/supervisor/conf.d/php-fpm.conf && \
-    cp rootfs/supervisor/conf.d/apache2.conf /etc/supervisor/conf.d/apache2.conf && \
+    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
+
+WORKDIR /var/www/html
+COPY public ./public
+COPY rootfs ./rootfs
+RUN cp -r rootfs/services.d/php-fpm /etc/services.d/php-fpm && \
+    cp -r rootfs/services.d/apache2 /etc/services.d/apache2 && \
     cp -r rootfs/apache2/ /etc/ && \
     chmod -R 775 /var/www && \
     chown -R www-data:www-data /var/www/html && \
-    rm -rf rootfs/ /var/cache/apk/*;
+    rm -rf rootfs/;
 
 # Running both php-fpm and apache in foreground to intercept connections
 STOPSIGNAL SIGTERM
 EXPOSE 80 443
-CMD ["supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]
+ENTRYPOINT ["/init"]

--- a/alpine-nginx.Dockerfile
+++ b/alpine-nginx.Dockerfile
@@ -2,29 +2,33 @@ FROM php:7.4.4-fpm-alpine3.11
 LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
 # Install NGINX and other OS support for images.
-RUN apk update && \
-    apk add --no-cache bash nginx supervisor libjpeg-turbo-dev libpng-dev freetype-dev libzip-dev postgresql-dev;
+ARG S6_VERSION=1.22.1.0
+RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+    tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
+    rm /tmp/s6-overlay-amd64.tar.gz && \
+    apk update && \
+    apk add --no-cache bash nginx libjpeg-turbo-dev libpng-dev freetype-dev libzip-dev postgresql-dev && \
+    rm -rf /var/cache/apk/*;
 
 # Configure NGINX, PHP Modules and Supervisor
-WORKDIR /var/www/html
-COPY public ./public
-COPY rootfs ./rootfs
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install pdo_mysql mysqli pdo_pgsql pgsql gd zip; \
     mkdir -p /run/nginx && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
-    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
-    mkdir /etc/supervisor && mkdir /etc/supervisor/conf.d && \
-    cp rootfs/supervisor/supervisord.conf /etc/supervisor/supervisord.conf && \
-    cp rootfs/supervisor/conf.d/php-fpm.conf /etc/supervisor/conf.d/php-fpm.conf && \
-    cp rootfs/supervisor/conf.d/nginx.conf /etc/supervisor/conf.d/nginx.conf && \
+    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
+
+WORKDIR /var/www/html
+COPY public ./public
+COPY rootfs ./rootfs
+RUN cp -r rootfs/services.d/php-fpm /etc/services.d/ && \
+    cp -r rootfs/services.d/nginx /etc/services.d/ && \
     cp -r rootfs/nginx/ /etc/ && \
     chmod -R 775 /var/www && \
     chown -R www-data:www-data /var/www/html && \
-    rm -rf rootfs/ /var/cache/apk/*;
+    rm -rf rootfs/;
 
 # Running both php-fpm and NGINX in foreground to intercept connections
 STOPSIGNAL SIGTERM
 EXPOSE 80 443
-CMD ["supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]
+ENTRYPOINT ["/init"]

--- a/debian-apache.Dockerfile
+++ b/debian-apache.Dockerfile
@@ -2,25 +2,29 @@ FROM php:7.4.4-fpm-buster
 LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
 # Install Apache and other OS support for images.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends supervisor apache2 libjpeg62-turbo-dev libpng-dev libfreetype6-dev libzip-dev libpq-dev && \
+ARG S6_VERSION=1.22.1.0
+RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+    tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
+    rm /tmp/s6-overlay-amd64.tar.gz && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends apache2 libjpeg62-turbo-dev libpng-dev libfreetype6-dev libzip-dev libpq-dev && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/man/* /usr/share/doc/*;
 
 # Configure Apache, PHP Modules and Supervisor
-WORKDIR /var/www/html
-COPY public ./public
-COPY rootfs ./rootfs
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install pdo_mysql mysqli pdo_pgsql pgsql gd zip && \
     a2enmod macro actions proxy_fcgi rewrite ssl && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
-    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
-    cp rootfs/supervisor/supervisord.conf /etc/supervisor/supervisord.conf && \
-    cp rootfs/supervisor/conf.d/php-fpm.conf /etc/supervisor/conf.d/php-fpm.conf && \
-    cp rootfs/supervisor/conf.d/apache2.conf /etc/supervisor/conf.d/apache2.conf && \
+    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
+
+WORKDIR /var/www/html
+COPY public ./public
+COPY rootfs ./rootfs
+RUN cp -r rootfs/services.d/php-fpm /etc/services.d/php-fpm && \
+    cp -r rootfs/services.d/apache2 /etc/services.d/apache2 && \
     cp -r rootfs/apache2/ /etc/ && \
     chmod 6444 /var/log/apache2 && \
     chown -R www-data:www-data /var/www/html && \
@@ -29,4 +33,4 @@ RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.
 # Running both php-fpm and Apache in foreground to intercept connections
 STOPSIGNAL SIGTERM
 EXPOSE 80 443
-CMD ["supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]
+CMD ["/init"]

--- a/debian-apache.Dockerfile
+++ b/debian-apache.Dockerfile
@@ -12,7 +12,7 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/man/* /usr/share/doc/*;
 
-# Configure Apache, PHP Modules and Supervisor
+# Configure Apache, PHP Modules and S6
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install pdo_mysql mysqli pdo_pgsql pgsql gd zip && \
@@ -33,4 +33,4 @@ RUN cp -r rootfs/services.d/php-fpm /etc/services.d/php-fpm && \
 # Running both php-fpm and Apache in foreground to intercept connections
 STOPSIGNAL SIGTERM
 EXPOSE 80 443
-CMD ["/init"]
+ENTRYPOINT ["/init"]

--- a/debian-nginx.Dockerfile
+++ b/debian-nginx.Dockerfile
@@ -2,24 +2,28 @@ FROM php:7.4.4-fpm-buster
 LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
 # Install NGINX and other OS support for images.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends supervisor nginx libjpeg62-turbo-dev libpng-dev libfreetype6-dev libzip-dev libpq-dev && \
+ARG S6_VERSION=1.22.1.0
+RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+    tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
+    rm /tmp/s6-overlay-amd64.tar.gz && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends nginx libjpeg62-turbo-dev libpng-dev libfreetype6-dev libzip-dev libpq-dev && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/man/* /usr/share/doc/*;
 
 # Configure NGINX, PHP Modules and Supervisor
-WORKDIR /var/www/html
-COPY public ./public
-COPY rootfs ./rootfs
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install pdo_mysql mysqli pdo_pgsql pgsql gd zip; \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
-    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
-    cp rootfs/supervisor/supervisord.conf /etc/supervisor/supervisord.conf && \
-    cp rootfs/supervisor/conf.d/php-fpm.conf /etc/supervisor/conf.d/php-fpm.conf && \
-    cp rootfs/supervisor/conf.d/nginx.conf /etc/supervisor/conf.d/nginx.conf && \
+    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
+
+WORKDIR /var/www/html
+COPY public ./public
+COPY rootfs ./rootfs
+RUN cp -r rootfs/services.d/php-fpm /etc/services.d/ && \
+    cp -r rootfs/services.d/nginx /etc/services.d/ && \
     cp -r rootfs/nginx/ /etc/ && \
     mv /etc/nginx/conf.d/default.conf /etc/nginx/sites-enabled/default && \
     chmod 6444 /var/log/nginx && \
@@ -29,4 +33,4 @@ RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.
 # Running both php-fpm and NGINX in foreground to intercept connections
 STOPSIGNAL SIGTERM
 EXPOSE 80 443
-CMD ["supervisord", "-n", "-c", "/etc/supervisor/supervisord.conf"]
+ENTRYPOINT ["/init"]

--- a/debian-nginx.Dockerfile
+++ b/debian-nginx.Dockerfile
@@ -12,7 +12,7 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/man/* /usr/share/doc/*;
 
-# Configure NGINX, PHP Modules and Supervisor
+# Configure NGINX, PHP Modules and S6
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install pdo_mysql mysqli pdo_pgsql pgsql gd zip; \

--- a/rootfs/services.d/apache2/run
+++ b/rootfs/services.d/apache2/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+apachectl -D FOREGROUND
+echo "apache is running"

--- a/rootfs/services.d/nginx/run
+++ b/rootfs/services.d/nginx/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+nginx -g "daemon off;"
+echo "nginx is running"

--- a/rootfs/services.d/php-fpm/run
+++ b/rootfs/services.d/php-fpm/run
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv sh
+
+exec php-fpm -F --nodaemonize


### PR DESCRIPTION
Replacing supervisor with s6 will reduce the overall Docker image size, while maintaining the needed functionalities of supervisor