### PR TITLE
update php image

### DIFF
--- a/docker/alpine/apache/Dockerfile
+++ b/docker/alpine/apache/Dockerfile
@@ -3,7 +3,8 @@ LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
 # Install Apache and other OS support for images.
 ARG S6_VERSION=2.0.0.1
-RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+RUN set -xe && \
+    curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz && \
     apk update && \
@@ -21,7 +22,8 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
     rm -rf /var/cache/apk/*;
 
 # Configure Apache, PHP Modules and S6
-RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
+RUN set -xe && \
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install \
         pdo_mysql \

--- a/docker/alpine/apache/Dockerfile
+++ b/docker/alpine/apache/Dockerfile
@@ -1,12 +1,14 @@
 FROM php:7.4.10-fpm-alpine3.12
 LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
-# Install Apache and other OS support for images.
+# Install S6 Overlay
 ARG S6_VERSION=2.0.0.1
-RUN set -xe && \
-    curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
-    rm /tmp/s6-overlay-amd64.tar.gz && \
+    rm /tmp/s6-overlay-amd64.tar.gz;
+
+# Install Apache and other OS support for images.
+RUN set -xe && \
     apk update && \
     apk add --no-cache \
         bash \
@@ -21,7 +23,7 @@ RUN set -xe && \
         postgresql-dev && \
     rm -rf /var/cache/apk/*;
 
-# Configure PHP Modules and Apache
+# Configure PHP Modules
 RUN set -xe && \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     pear config-set php_ini "$PHP_INI_DIR" && \
@@ -39,7 +41,10 @@ RUN set -xe && \
     apk del build-deps && \
     docker-php-ext-enable mongodb redis && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
-    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
+    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
+
+# Configure Apache
+RUN set -xe && \
     sed -i 's@^#LoadModule actions_module modules/mod_actions\.so@LoadModule actions_module modules/mod_actions.so@' /etc/apache2/httpd.conf && \
     sed -i 's@^#LoadModule macro_module modules/mod_macro\.so@LoadModule macro_module modules/mod_macro.so@' /etc/apache2/httpd.conf && \
     sed -i 's@^#LoadModule rewrite_module modules/mod_rewrite\.so@LoadModule rewrite_module modules/mod_rewrite.so@' /etc/apache2/httpd.conf && \

--- a/docker/alpine/apache/Dockerfile
+++ b/docker/alpine/apache/Dockerfile
@@ -21,7 +21,7 @@ RUN set -xe && \
         postgresql-dev && \
     rm -rf /var/cache/apk/*;
 
-# Configure Apache, PHP Modules and S6
+# Configure PHP Modules and Apache
 RUN set -xe && \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
@@ -32,14 +32,14 @@ RUN set -xe && \
         pgsql \
         gd \
         zip && \
+    echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
+    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
     sed -i 's@^#LoadModule actions_module modules/mod_actions\.so@LoadModule actions_module modules/mod_actions.so@' /etc/apache2/httpd.conf && \
     sed -i 's@^#LoadModule macro_module modules/mod_macro\.so@LoadModule macro_module modules/mod_macro.so@' /etc/apache2/httpd.conf && \
     sed -i 's@^#LoadModule rewrite_module modules/mod_rewrite\.so@LoadModule rewrite_module modules/mod_rewrite.so@' /etc/apache2/httpd.conf && \
     sed -ri -e 's!DocumentRoot "/var/www/localhost/htdocs"!DocumentRoot "/var/www/html/public/"!g' /etc/apache2/httpd.conf && \
     echo 'Include /etc/apache2/sites-enabled/*.conf' >> /etc/apache2/httpd.conf && \
-    ln -s /usr/sbin/httpd /usr/sbin/apachectl && \
-    echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
-    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
+    ln -s /usr/sbin/httpd /usr/sbin/apachectl;
 
 WORKDIR /var/www/html
 COPY container .

--- a/docker/alpine/apache/Dockerfile
+++ b/docker/alpine/apache/Dockerfile
@@ -24,6 +24,7 @@ RUN set -xe && \
 # Configure PHP Modules and Apache
 RUN set -xe && \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
+    pear config-set php_ini "$PHP_INI_DIR" && \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install \
         pdo_mysql \
@@ -32,6 +33,11 @@ RUN set -xe && \
         pgsql \
         gd \
         zip && \
+    apk add --no-cache --virtual build-deps ${PHPIZE_DEPS} && \
+    pecl install mongodb redis && \
+    pecl clear-cache && \
+    apk del build-deps && \
+    docker-php-ext-enable mongodb redis && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
     echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
     sed -i 's@^#LoadModule actions_module modules/mod_actions\.so@LoadModule actions_module modules/mod_actions.so@' /etc/apache2/httpd.conf && \

--- a/docker/alpine/apache/Dockerfile
+++ b/docker/alpine/apache/Dockerfile
@@ -7,13 +7,29 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz && \
     apk update && \
-    apk add --no-cache bash apache2 apache2-proxy apache2-ssl libjpeg-turbo-dev libpng-dev freetype-dev libzip-dev postgresql-dev && \
+    apk add --no-cache \
+        bash \
+        apache2 \
+        apache2-proxy \
+        apache2-ssl && \
+    apk add --no-cache \
+        libjpeg-turbo-dev \
+        libpng-dev \
+        freetype-dev \
+        libzip-dev \
+        postgresql-dev && \
     rm -rf /var/cache/apk/*;
 
 # Configure Apache, PHP Modules and S6
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
-    docker-php-ext-install pdo_mysql mysqli pdo_pgsql pgsql gd zip; \
+    docker-php-ext-install \
+        pdo_mysql \
+        mysqli \
+        pdo_pgsql \
+        pgsql \
+        gd \
+        zip && \
     sed -i 's@^#LoadModule actions_module modules/mod_actions\.so@LoadModule actions_module modules/mod_actions.so@' /etc/apache2/httpd.conf && \
     sed -i 's@^#LoadModule macro_module modules/mod_macro\.so@LoadModule macro_module modules/mod_macro.so@' /etc/apache2/httpd.conf && \
     sed -i 's@^#LoadModule rewrite_module modules/mod_rewrite\.so@LoadModule rewrite_module modules/mod_rewrite.so@' /etc/apache2/httpd.conf && \

--- a/docker/alpine/nginx/Dockerfile
+++ b/docker/alpine/nginx/Dockerfile
@@ -1,12 +1,14 @@
 FROM php:7.4.10-fpm-alpine3.12
 LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
-# Install NGINX and other OS support for images.
+# Install S6 Overlay
 ARG S6_VERSION=2.0.0.1
-RUN set -xe && \
-    curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
-    rm /tmp/s6-overlay-amd64.tar.gz && \
+    rm /tmp/s6-overlay-amd64.tar.gz;
+
+# Install NGINX and other OS support for images.
+RUN set -xe && \
     apk update && \
     apk add --no-cache \
         bash \
@@ -36,8 +38,10 @@ RUN set -xe && \
     apk del build-deps && \
     docker-php-ext-enable mongodb redis && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
-    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
-    mkdir -p /run/nginx;
+    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
+
+# Add NGINX run folder
+RUN mkdir -p /run/nginx
 
 WORKDIR /var/www/html
 COPY container .

--- a/docker/alpine/nginx/Dockerfile
+++ b/docker/alpine/nginx/Dockerfile
@@ -18,7 +18,7 @@ RUN set -xe && \
         postgresql-dev && \
     rm -rf /var/cache/apk/*;
 
-# Configure NGINX, PHP Modules and Supervisor
+# Configure PHP Modules
 RUN set -xe && \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
@@ -29,9 +29,9 @@ RUN set -xe && \
         pgsql \
         gd \
         zip && \
-    mkdir -p /run/nginx && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
-    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
+    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
+    mkdir -p /run/nginx;
 
 WORKDIR /var/www/html
 COPY container .

--- a/docker/alpine/nginx/Dockerfile
+++ b/docker/alpine/nginx/Dockerfile
@@ -7,13 +7,26 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz && \
     apk update && \
-    apk add --no-cache bash nginx libjpeg-turbo-dev libpng-dev freetype-dev libzip-dev postgresql-dev && \
+    apk add --no-cache \
+        bash \
+        nginx \
+        libjpeg-turbo-dev \
+        libpng-dev \
+        freetype-dev \
+        libzip-dev \
+        postgresql-dev && \
     rm -rf /var/cache/apk/*;
 
 # Configure NGINX, PHP Modules and Supervisor
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
-    docker-php-ext-install pdo_mysql mysqli pdo_pgsql pgsql gd zip; \
+    docker-php-ext-install \
+        pdo_mysql \
+        mysqli \
+        pdo_pgsql \
+        pgsql \
+        gd \
+        zip && \
     mkdir -p /run/nginx && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
     echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;

--- a/docker/alpine/nginx/Dockerfile
+++ b/docker/alpine/nginx/Dockerfile
@@ -21,6 +21,7 @@ RUN set -xe && \
 # Configure PHP Modules
 RUN set -xe && \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
+    pear config-set php_ini "$PHP_INI_DIR" && \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install \
         pdo_mysql \
@@ -29,6 +30,11 @@ RUN set -xe && \
         pgsql \
         gd \
         zip && \
+    apk add --no-cache --virtual build-deps ${PHPIZE_DEPS} && \
+    pecl install mongodb redis && \
+    pecl clear-cache && \
+    apk del build-deps && \
+    docker-php-ext-enable mongodb redis && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
     echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
     mkdir -p /run/nginx;

--- a/docker/alpine/nginx/Dockerfile
+++ b/docker/alpine/nginx/Dockerfile
@@ -3,7 +3,8 @@ LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
 # Install NGINX and other OS support for images.
 ARG S6_VERSION=2.0.0.1
-RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+RUN set -xe && \
+    curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz && \
     apk update && \
@@ -18,7 +19,8 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
     rm -rf /var/cache/apk/*;
 
 # Configure NGINX, PHP Modules and Supervisor
-RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
+RUN set -xe && \
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install \
         pdo_mysql \

--- a/docker/debian/apache/Dockerfile
+++ b/docker/debian/apache/Dockerfile
@@ -7,7 +7,13 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz && \
     apt-get update && \
-    apt-get install -y --no-install-recommends apache2 libjpeg62-turbo-dev libpng-dev libfreetype6-dev libzip-dev libpq-dev && \
+    apt-get install -y --no-install-recommends \
+        apache2 \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libfreetype6-dev \
+        libzip-dev \
+        libpq-dev && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/man/* /usr/share/doc/*;
@@ -15,8 +21,19 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
 # Configure Apache, PHP Modules and S6
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
-    docker-php-ext-install pdo_mysql mysqli pdo_pgsql pgsql gd zip && \
-    a2enmod macro actions proxy_fcgi rewrite ssl && \
+    docker-php-ext-install \
+        pdo_mysql \
+        mysqli \
+        pdo_pgsql \
+        pgsql \
+        gd \
+        zip && \
+    a2enmod \
+        macro \
+        actions \
+        proxy_fcgi \
+        rewrite \
+        ssl && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
     echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
 

--- a/docker/debian/apache/Dockerfile
+++ b/docker/debian/apache/Dockerfile
@@ -1,12 +1,14 @@
 FROM php:7.4.10-fpm-buster
 LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
-# Install Apache and other OS support for images.
+# Install S6 Overlay
 ARG S6_VERSION=2.0.0.1
-RUN set -xe && \
-    curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
-    rm /tmp/s6-overlay-amd64.tar.gz && \
+    rm /tmp/s6-overlay-amd64.tar.gz;
+
+# Install Apache and other OS support for images.
+RUN set -xe && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         apache2 \
@@ -19,7 +21,7 @@ RUN set -xe && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/man/* /usr/share/doc/*;
 
-# Configure PHP Modules and Apache
+# Configure PHP Modules
 RUN set -xe && \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     pear config-set php_ini "$PHP_INI_DIR" && \
@@ -34,7 +36,10 @@ RUN set -xe && \
     pecl install mongodb redis && \
     pecl clear-cache && \        
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
-    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
+    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
+
+# Configure Apache
+RUN set -xe && \
     a2enmod \
         macro \
         actions \

--- a/docker/debian/apache/Dockerfile
+++ b/docker/debian/apache/Dockerfile
@@ -19,7 +19,7 @@ RUN set -xe && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/man/* /usr/share/doc/*;
 
-# Configure Apache, PHP Modules and S6
+# Configure PHP Modules and Apache
 RUN set -xe && \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
@@ -30,14 +30,14 @@ RUN set -xe && \
         pgsql \
         gd \
         zip && \
+    echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
+    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
     a2enmod \
         macro \
         actions \
         proxy_fcgi \
         rewrite \
-        ssl && \
-    echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
-    echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
+        ssl;
 
 WORKDIR /var/www/html
 COPY container .

--- a/docker/debian/apache/Dockerfile
+++ b/docker/debian/apache/Dockerfile
@@ -22,6 +22,7 @@ RUN set -xe && \
 # Configure PHP Modules and Apache
 RUN set -xe && \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
+    pear config-set php_ini "$PHP_INI_DIR" && \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install \
         pdo_mysql \
@@ -30,6 +31,8 @@ RUN set -xe && \
         pgsql \
         gd \
         zip && \
+    pecl install mongodb redis && \
+    pecl clear-cache && \        
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
     echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini && \
     a2enmod \

--- a/docker/debian/apache/Dockerfile
+++ b/docker/debian/apache/Dockerfile
@@ -3,7 +3,8 @@ LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
 # Install Apache and other OS support for images.
 ARG S6_VERSION=2.0.0.1
-RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+RUN set -xe && \
+    curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz && \
     apt-get update && \
@@ -19,7 +20,8 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
     rm -rf /var/lib/apt/lists/* /usr/share/man/* /usr/share/doc/*;
 
 # Configure Apache, PHP Modules and S6
-RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
+RUN set -xe && \
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install \
         pdo_mysql \

--- a/docker/debian/nginx/Dockerfile
+++ b/docker/debian/nginx/Dockerfile
@@ -1,12 +1,14 @@
 FROM php:7.4.10-fpm-buster
 LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
-# Install NGINX and other OS support for images.
+# Install S6 Overlay
 ARG S6_VERSION=2.0.0.1
-RUN set -xe && \
-    curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
-    rm /tmp/s6-overlay-amd64.tar.gz && \
+    rm /tmp/s6-overlay-amd64.tar.gz;
+
+# Install NGINX and other OS support for images.
+RUN set -xe && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         nginx \

--- a/docker/debian/nginx/Dockerfile
+++ b/docker/debian/nginx/Dockerfile
@@ -3,7 +3,8 @@ LABEL maintainer="Sam Huynh <samhwang2112.dev@gmail.com>"
 
 # Install NGINX and other OS support for images.
 ARG S6_VERSION=2.0.0.1
-RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
+RUN set -xe && \
+    curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz && \
     apt-get update && \
@@ -19,7 +20,8 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
     rm -rf /var/lib/apt/lists/* /usr/share/man/* /usr/share/doc/*;
 
 # Configure NGINX, PHP Modules and S6
-RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
+RUN set -xe && \
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
     docker-php-ext-install \
         pdo_mysql \

--- a/docker/debian/nginx/Dockerfile
+++ b/docker/debian/nginx/Dockerfile
@@ -30,6 +30,8 @@ RUN set -xe && \
         pgsql \
         gd \
         zip && \
+    pecl install mongodb redis && \
+    pecl clear-cache && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
     echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
 

--- a/docker/debian/nginx/Dockerfile
+++ b/docker/debian/nginx/Dockerfile
@@ -19,7 +19,7 @@ RUN set -xe && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/man/* /usr/share/doc/*;
 
-# Configure NGINX, PHP Modules and S6
+# Configure PHP Modules
 RUN set -xe && \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \

--- a/docker/debian/nginx/Dockerfile
+++ b/docker/debian/nginx/Dockerfile
@@ -7,7 +7,13 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz && \
     apt-get update && \
-    apt-get install -y --no-install-recommends nginx libjpeg62-turbo-dev libpng-dev libfreetype6-dev libzip-dev libpq-dev && \
+    apt-get install -y --no-install-recommends \
+        nginx \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libfreetype6-dev \
+        libzip-dev \
+        libpq-dev && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /usr/share/man/* /usr/share/doc/*;
@@ -15,7 +21,13 @@ RUN curl -LkSso /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/
 # Configure NGINX, PHP Modules and S6
 RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/server.key -out /etc/ssl/server.crt -subj "/C=AU/ST=VIC/L=Melbourne/O=Localhost/CN=Localhost"; \
     docker-php-ext-configure gd --with-jpeg=/usr/include --with-freetype=/usr/include && \
-    docker-php-ext-install pdo_mysql mysqli pdo_pgsql pgsql gd zip; \
+    docker-php-ext-install \
+        pdo_mysql \
+        mysqli \
+        pdo_pgsql \
+        pgsql \
+        gd \
+        zip && \
     echo 'error_log = "/dev/stderr"' >> /usr/local/etc/php/php.ini && \
     echo 'access_log = "/dev/stdout"' >> /usr/local/etc/php/php.ini;
 


### PR DESCRIPTION
- Break up multi package installations into a multiline script
- Set explicit in image to track build steps
- Move PHP config on top of Apache/NGINX config block
- Add support for redis and mongodb
- Split up build and install steps for more caching
